### PR TITLE
Fix saving now playing queue to a new playlist

### DIFF
--- a/src/components/now-playing/playlist-saver/playlist-saver-settings.srv.js
+++ b/src/components/now-playing/playlist-saver/playlist-saver-settings.srv.js
@@ -34,19 +34,19 @@ export default class PlaylistSaverSettings {
 
     addTracks (tracksIds) {
     	// var addTrackPromises = tracksIds.map(addTrack);
-        this.defer = $q.defer();
+        this.defer = this.$q.defer();
         this.tracks = tracksIds;
         this.index = 0;
         this.totalTracks = tracksIds.length;
         this.addTrack(tracksIds[0]);
     	// return $q.when(addTrackPromises);
-        return defer.promise;
+        return this.defer.promise;
     }
 
     addTrack (media) {
         return this.UserPlaylists
             .addToPlaylist(this.playlist.id, media)
-            .then(onAddSuccess, onAddFailed);
+            .then(onAddSuccess.bind(this), onAddFailed.bind(this));
 
         function onAddSuccess(response) {
             this.index++;

--- a/src/components/now-playing/playlist-saver/playlist-saver.ctrl.js
+++ b/src/components/now-playing/playlist-saver/playlist-saver.ctrl.js
@@ -2,7 +2,7 @@
 export default class PlaylistSaverCtrl {
 
     constructor ($scope, PlaylistSaverSettings) {
-        this.$scope = $scope;
+        Object.assign(this, { $scope, PlaylistSaverSettings });
         this.playlist = PlaylistSaverSettings.playlist;
         this.inSaveMode = false;
     }
@@ -11,10 +11,10 @@ export default class PlaylistSaverCtrl {
     	this.inSaveMode = true;
     	this.PlaylistSaverSettings
             .save(this.tracks)
-            .then(onSuccess, onFail);
+            .then(onSuccess.bind(this), onFail.bind(this));
 
     	function onSuccess (playlistId) {
-    		this.onSave(playlistId);
+            this.onSave({ playlistId: playlistId });
     		this.inSaveMode = false;
     		this.$scope.$apply();
     	}


### PR DESCRIPTION
First of all, thanks @orizens for the awesome software. I've been using it every day since I discovered it. I wasn't able to save a new playlist from the now-playing queue, this was the error (shown from the dev server for sourcemaps):
```
TypeError: Cannot read property 'save' of undefined
    at PlaylistSaverCtrl.save (playlist-saver.ctrl.js:12)
```

The fault was that `PlaylistSaverSettings` wasn't set on the class context. From there I traced a trail of minor faults (variable references that were out of scope/context, and a few functions that needed to be lexically bound to the class context), and was able to get the playlist to save as expected. Also had to make a correction to calling the Angular function binding `onSave` from `PlaylistSaverCtrl`, which has to be done with an object, so that `NowPlayingCtrl` would hide the playlist saver after the saving is completed.

If there is any procedure I should do to wrap up this PR, let me know!